### PR TITLE
Disabled overspending points

### DIFF
--- a/simpleCharacterCreator.html
+++ b/simpleCharacterCreator.html
@@ -18,7 +18,7 @@
   
 <div class="container-fluid mt-2 text-center text-white">
   <h1>Simplified D&amp;D 5e Character Creator</h1>
-  <p>This is a proof of concept to create the character creator webpage. A working version is currently being designed.</p>
+  <p>Backgrounds and Skill Proficiencies to be added. Currently working on Limiting Point Buy Inputs for ease of use</p>
 </div>
 
 <div class="container-fluid mt-4 gx-4 text-left text-white" id="charOptions">
@@ -68,9 +68,9 @@
 <div class="container-fluid mt-4 gx-4 text-white" id="charStats">
     <div class="d-flex justify-content-between h3">
         <div>Enter your character stats</div>
-        <div>Remaining Points: <span id="pointsRemaining">27</span></div>
         </div>
     <table class="table-dark table-responsive w-100 text-center" id="statTable" oninput="calcStats()">
+        <caption class="text-white">Remaining Points: <span id="pointsRemaining">27</span> / 27</caption>
         <thead>
             <tr>
                 <th scope="col"></th>


### PR DESCRIPTION
Added functionality to disable point buy options if there were not enough points remaining to buy them.
Also included redundant fixes to point buy if remaining points was less than 0.
Moved remaining points to caption under the table and add ' / 27' to signify total available points